### PR TITLE
Set host_port on speaker daemon set

### DIFF
--- a/speaker_daemonset.tf
+++ b/speaker_daemonset.tf
@@ -108,6 +108,7 @@ resource "kubernetes_daemonset" "speaker" {
           port {
             name           = "monitoring"
             container_port = 7472
+            host_port      = 7472
           }
 
           resources {


### PR DESCRIPTION
Hey there,
This is a nop change which should not affect the overall behaviour but solves a rather annoying issue - each time the module is ran it finds that the port is set to 7472 and tries to unset it. Once unset from terraform, it get's set back from te k8s controller and the next time terraform is ran it sees figures it needs to do the same change.

Adding the host port to the config should solve this.