### PR TITLE
Added optional variables for controller node_selector and toleration

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,13 @@ variable "metallb_version" {
   type        = string
   description = "MetalLB Version e.g. 0.9.5"
 }
+
+variable "controller_toleration" {
+  default = []
+  type    = list(map(any))
+}
+
+variable "controller_node_selector" {
+  default = {}
+  type    = map(any)
+}


### PR DESCRIPTION
This change adds the ability to set toleration for the controller deployment and to specify additional node_selector terms.